### PR TITLE
Fix: Hide GPA for Manipal education entry and update types

### DIFF
--- a/components/ui/education-section.tsx
+++ b/components/ui/education-section.tsx
@@ -4,7 +4,18 @@ import { motion } from 'framer-motion';
 import { GlowingEffect } from '@/components/ui/glowing-effect';
 import { GraduationCap, Calendar, MapPin, Award, BookOpen, Users } from 'lucide-react';
 
-const educationData = [
+interface EducationEntry {
+  period: string;
+  degree: string;
+  institution: string;
+  location: string;
+  status: "current" | "completed";
+  gpa?: string; // GPA is optional
+  highlights: string[];
+  icon: JSX.Element;
+}
+
+const educationData: EducationEntry[] = [
   {
     period: "2025 – present",
     degree: "B.E. (Hons) Software Engineering",
@@ -22,7 +33,6 @@ const educationData = [
     institution: "Manipal Academy of Higher Education",
     location: "Manipal, India",
     status: "completed",
-    gpa: "3.54/4.0",
     highlights: [
       "AI/ML specialization with focus on Deep Learning",
       "Published heart-disease prediction research",


### PR DESCRIPTION
This commit addresses the request to hide the GPA for the Manipal Academy of Higher Education entry in the education section.

Changes:
- Removed the `gpa` property from the Manipal entry within the `educationData` array in `components/ui/education-section.tsx`.
- To resolve a TypeScript error that occurred because the `gpa` field was no longer uniformly present across all education entries, an `EducationEntry` interface was introduced. In this interface, the `gpa` property is now optional (`gpa?: string;`).
- The `educationData` array is now typed with `EducationEntry[]`.

This ensures that the GPA for the Manipal entry is no longer displayed, and the codebase maintains type safety. The application builds successfully.